### PR TITLE
Get Prize bug fixes

### DIFF
--- a/src/controllers/ProjectsController.ts
+++ b/src/controllers/ProjectsController.ts
@@ -167,7 +167,7 @@ export const getAllPrizes = async (
   res: Response
 ): Promise<void> => {
   try {
-    const result = await Prize.find();
+    const result = await Prize.find().populate("provider").populate("winner");
 
     res.status(200).json(result);
   } catch (err) {
@@ -187,7 +187,9 @@ export const getPrizeByID = async (
   const { id } = req.params;
 
   try {
-    const result = await Prize.findById(id);
+    const result = await Prize.findById(id)
+      .populate("provider")
+      .populate("winner");
 
     res.json(result);
   } catch (err) {

--- a/src/routes/prizes.ts
+++ b/src/routes/prizes.ts
@@ -129,7 +129,7 @@ router.patch("/:id", isAdmin, asyncCatch(editPrize));
  *       500:
  *          description: Internal Server Error.
  */
-router.get("/prizes/:id", asyncCatch(getPrizeByID));
+router.get("/:id", asyncCatch(getPrizeByID));
 
 /**
  * @swagger


### PR DESCRIPTION
Resolves #44 

- The winner and provider fields are optional objectIDs - that's why some prizes in the get response don't include them.
- Also added auto population of the winner and provider fields if they exist in the get prize responses.