### PR TITLE
Verification Code Endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "tartanhacks-backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -17,6 +16,7 @@
         "@zerollup/ts-transform-paths": "^1.7.18",
         "bcrypt": "^5.0.1",
         "cors": "^2.8.5",
+        "crypto": "^1.0.1",
         "dotenv": "^10.0.0",
         "email-templates": "^8.0.7",
         "express": "^4.17.1",
@@ -3750,6 +3750,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -15381,6 +15387,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-random-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@zerollup/ts-transform-paths": "^1.7.18",
     "bcrypt": "^5.0.1",
     "cors": "^2.8.5",
+    "crypto": "^1.0.1",
     "dotenv": "^10.0.0",
     "email-templates": "^8.0.7",
     "express": "^4.17.1",

--- a/src/_types/User.d.ts
+++ b/src/_types/User.d.ts
@@ -14,6 +14,8 @@ export interface IUser extends Document {
   lastLogin?: Date;
   createdAt: Date;
   updatedAt: Date;
+  verificationCode?: string;
+  verificationExpiry?: Date;
   /**
    * Check if a password matches the stored hash
    * @param password password to verify
@@ -31,6 +33,10 @@ export interface IUser extends Document {
    * Generate an email verification token for this account
    */
   generateEmailVerificationToken: () => string;
+  /**
+   * Generate a new verification code and update the user
+   */
+  updateVerificationCode: () => Promise<IUser>;
 }
 
 export interface IUserModel extends Model<IUser> {

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -9,7 +9,8 @@ import { bad, error, notFound } from "../util/error";
 import * as EmailController from "./EmailController";
 import { isRegistrationOpen } from "./SettingsController";
 import * as StatusController from "./StatusController";
-import { getByToken } from "./UserController";
+import { getByCode, getByToken } from "./UserController";
+import { findUserTeam } from "./TeamController";
 
 /**
  * Register a user
@@ -263,6 +264,32 @@ export const sendPasswordResetEmail = async (
     } catch (err) {
       error(res, "Could not send password reset email");
     }
+  } catch (err) {
+    console.error(err);
+    return error(res);
+  }
+};
+
+export const getUserByVerificationCode = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const { code } = req.body;
+
+  if (code == null) {
+    return bad(res, "Missing verification code");
+  }
+
+  try {
+    const user = await getByCode(code);
+    if (user === null) {
+      return notFound(res, "Invalid verification code");
+    }
+
+    const team = findUserTeam(user.id);
+    res.status(200).json({
+      user, team
+    });
   } catch (err) {
     console.error(err);
     return error(res);

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,5 +1,7 @@
 import User from "../models/User";
 import { IUser } from "../_types/User";
+import { Request, Response } from "express";
+import { bad, error, notFound, unauthorized } from "../util/error";
 
 /**
  * Get a User by their authentication token
@@ -13,5 +15,46 @@ export const getByToken = async (token: string): Promise<IUser> => {
     return user;
   } catch (err) {
     return null;
+  }
+};
+
+/**
+ * Get a User by their verification code
+ * @param code verification code
+ * @returns the user associated with the verification code, if it is not expired
+ */
+export const getByCode = async (code: string): Promise<IUser> => {
+  try {
+    const user = await User.findOne({ verificationCode: code });
+    if (new Date() <= user.verificationExpiry) {
+      return user;
+    } else {
+      return null;
+    }
+  } catch (err) {
+    return null;
+  }
+};
+
+/**
+ * Get the current verification code, or generate a new one if it is expired
+ */
+export const getOwnVerificationCode = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const user = res.locals.user;
+
+  try {
+    if (!user.verificationCode || user.verificationExpiry <= new Date()) {
+      await user.updateVerificationCode();
+    }
+
+    res
+      .status(200)
+      .json({ code: user.verificationCode, expiry: user.verificationExpiry });
+  } catch (err) {
+    console.log(err);
+    error(res);
   }
 };

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -8,6 +8,7 @@ import {
   verify,
 } from "../controllers/AuthController";
 import { asyncCatch } from "../util/asyncCatch";
+import { getUserByVerificationCode } from "../controllers/AuthController";
 
 const router: Router = express.Router();
 
@@ -198,5 +199,34 @@ router.post("/request-reset", asyncCatch(sendPasswordResetEmail));
  *          description: Internal Server Error.
  */
 router.post("/reset/password", asyncCatch(resetPassword));
+
+/**
+ * @swagger
+ * /auth/discord/verification-code:
+ *   post:
+ *     summary: Get a user and their team using a verification code
+ *     tags: [Authentication Module]
+ *     description: Get a user and their team using a verification code. Access - Open
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               code:
+ *                 type: string
+ *     responses:
+ *       200:
+ *          description: Success.
+ *       404:
+ *          description: Verification code invalid.
+ *       500:
+ *          description: Internal Server Error.
+ */
+router.post(
+  "/discord/verification-code",
+  asyncCatch(getUserByVerificationCode)
+);
 
 export default router;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -202,7 +202,7 @@ router.post("/reset/password", asyncCatch(resetPassword));
 
 /**
  * @swagger
- * /auth/discord/verification-code:
+ * /auth/discord/verify:
  *   post:
  *     summary: Get a user and their team using a verification code
  *     tags: [Authentication Module]
@@ -225,7 +225,7 @@ router.post("/reset/password", asyncCatch(resetPassword));
  *          description: Internal Server Error.
  */
 router.post(
-  "/discord/verification-code",
+  "/discord/verify",
   asyncCatch(getUserByVerificationCode)
 );
 

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -313,7 +313,7 @@ router.put("/decline", isAuthenticated, asyncCatch(declineAcceptance));
 
 /**
  * @swagger
- * /user/get-verification-code:
+ * /user/verification:
  *  get:
  *    summary: Get a user's verification code.
  *    security:
@@ -331,7 +331,7 @@ router.put("/decline", isAuthenticated, asyncCatch(declineAcceptance));
  *        description: Internal Server Error.
  */
 router.get(
-  "/get-verification-code",
+  "/verification",
   isAuthenticated,
   asyncCatch(getOwnVerificationCode)
 );

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,4 +1,5 @@
 import express, { Router } from "express";
+import { getOwnVerificationCode } from "src/controllers/UserController";
 import {
   declineAcceptance,
   displayNameAvailable,
@@ -309,5 +310,30 @@ router.put("/confirmation", isAuthenticated, asyncCatch(submitConfirmation));
  *        description: Internal Server Error.
  */
 router.put("/decline", isAuthenticated, asyncCatch(declineAcceptance));
+
+/**
+ * @swagger
+ * /user/get-verification-code:
+ *  get:
+ *    summary: Get a user's verification code.
+ *    security:
+ *    - apiKeyAuth: []
+ *    tags: [User Module]
+ *    description: Get a user's verification code. If it does not exist or is expired, generate a new one. Access - User
+ *    responses:
+ *      200:
+ *        description: Success.
+ *      400:
+ *        description: Bad request
+ *      403:
+ *        description: Unauthorized.
+ *      500:
+ *        description: Internal Server Error.
+ */
+router.get(
+  "/get-verification-code",
+  isAuthenticated,
+  asyncCatch(getOwnVerificationCode)
+);
 
 export default router;


### PR DESCRIPTION
Adds endpoints `/auth/discord/verification-code/` and `/user/get-verification-code`

- Right now, if a user doesn't have a verification code or their current code is expired, generates a new one. Should there be another endpoint to force the code to be re-generated?