### PR TITLE
Add support for test account generation with different statuses

### DIFF
--- a/src/_types/Confirmation.d.ts
+++ b/src/_types/Confirmation.d.ts
@@ -1,9 +1,8 @@
-import { Document } from "mongoose";
 
 /**
  * Type for Confirmation model
  */
-export interface IConfirmation extends Document {
+export interface IConfirmation {
   signatureLiability: boolean;
   signatureCodeOfConduct: boolean;
   willMentor: boolean;

--- a/src/controllers/TestAccount/accountCreator.ts
+++ b/src/controllers/TestAccount/accountCreator.ts
@@ -1,0 +1,108 @@
+import { ObjectId } from "bson";
+import { LeanDocument } from "mongoose";
+import {
+  animals,
+  colors,
+  names,
+  uniqueNamesGenerator,
+} from "unique-names-generator";
+import Profile from "../../models/Profile";
+import User from "../../models/User";
+import pickRandom from "../../util/pickRandom";
+import { Ethnicity, Gender } from "../../_enums/Profile";
+import { doesStatusImply, Status } from "../../_enums/Status";
+import { IProfile } from "../../_types/Profile";
+import { IUser } from "../../_types/User";
+import { getTartanHacks } from "../EventController";
+
+export interface TestAccount {
+  _id: ObjectId;
+  email: string;
+  password: string;
+  status: Status;
+  token: string;
+  profile?: LeanDocument<IProfile>;
+}
+
+const schools = [
+  "Carnegie Mellon University",
+  "Crimson Magenta University",
+  "Carved Watermelon University",
+  "Marvel Cinematic Universe",
+  "Carnegie Carnegie Carnegie",
+];
+
+/**
+ * Create a new test account with the specified status
+ */
+export async function createTestAccountWithStatus(
+  status: Status
+): Promise<TestAccount> {
+  const prefix = uniqueNamesGenerator({
+    dictionaries: [names, colors],
+    separator: "-",
+    length: 2,
+  });
+  const email = `${prefix}@tartanhacks.com`.toLowerCase();
+  const password = uniqueNamesGenerator({
+    dictionaries: [colors, animals],
+    length: 2,
+    separator: "-",
+  });
+  const hash = User.generateHash(password);
+
+  const user = new User({ email, password: hash, status });
+  await user.save();
+
+  let profile: IProfile | undefined = undefined;
+  if (doesStatusImply(status, Status.COMPLETED_PROFILE)) {
+    profile = await createTestProfileForUser(user);
+
+    if (doesStatusImply(status, Status.CONFIRMED)) {
+      profile.confirmation = {
+        signatureLiability: true,
+        signatureCodeOfConduct: true,
+        willMentor: false,
+      };
+      await profile.save();
+    }
+  }
+
+  const token = await user.generateAuthToken();
+
+  return {
+    ...user.toJSON(),
+    password,
+    token,
+    profile,
+  };
+}
+
+/**
+ * Create a completed profile for a user
+ */
+export async function createTestProfileForUser(user: IUser): Promise<IProfile> {
+  const event = await getTartanHacks();
+  const email = user.email;
+  const displayName = email.split("@")[0];
+  const [firstName, lastName] = displayName.split("-");
+  const school = pickRandom(schools);
+
+  const profile = new Profile({
+    event: event._id,
+    user: user._id,
+    firstName,
+    lastName,
+    displayName,
+    age: pickRandom([18, 19, 20, 21, 22, 23, 24]),
+    school,
+    graduationYear: 2024,
+    gender: pickRandom(Object.values(Gender)),
+    ethnicity: pickRandom(Object.values(Ethnicity)),
+    phoneNumber: "1234567890",
+    github: displayName,
+  });
+  await profile.save();
+
+  return profile;
+}

--- a/src/routes/test-account.ts
+++ b/src/routes/test-account.ts
@@ -3,7 +3,7 @@ import {
   createNewTestAccount,
   deleteAllTestAccounts,
   deleteTestAccount,
-} from "../controllers/TestAccountController";
+} from "../controllers/TestAccount";
 import { asyncCatch } from "../util/asyncCatch";
 import { isAdmin, isAuthenticated } from "./middleware";
 
@@ -21,10 +21,21 @@ const router: Router = express.Router();
  * /test-account:
  *   post:
  *     summary: Create a new short-lived test account
- *     tags: [Test Module]
+ *     tags: [Test Account Module]
  *     security:
  *     - apiKeyAuth: []
- *     description: Create a new test account. Access - Admin
+ *     description: Create a new test account. Access - Admin\
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status:
+ *                 type: string
+ *                 required: true
+ *                 enum: [UNVERIFIED, VERIFIED, COMPLETED_PROFILE, ADMITTED, REJECTED, CONFIRMED, DECLINED]
  *     responses:
  *       200:
  *           description: Success. Returns the login information for a new test account
@@ -40,7 +51,7 @@ router.post("/", isAuthenticated, isAdmin, asyncCatch(createNewTestAccount));
  * /test-account/all:
  *   delete:
  *     summary: Delete all test accounts
- *     tags: [Test Module]
+ *     tags: [Test Account Module]
  *     security:
  *     - apiKeyAuth: []
  *     description: Delete all test account. Access - Admin
@@ -64,7 +75,7 @@ router.delete(
  * /test-account/{id}:
  *   delete:
  *     summary: Delete a test account
- *     tags: [Test Module]
+ *     tags: [Test Account Module]
  *     security:
  *     - apiKeyAuth: []
  *     description: Delete a test account. Access - Admin

--- a/src/util/pickRandom.ts
+++ b/src/util/pickRandom.ts
@@ -1,0 +1,11 @@
+/**
+ * Select a random item from a list of elements
+ */
+export default function pickRandom<T>(elements: T[]): T {
+  if (elements.length == 0) {
+    throw new Error("Cannot select a random element from an empty array!");
+  }
+
+  const index = Math.floor(Math.random() * elements.length);
+  return elements[index];
+}


### PR DESCRIPTION
# Description

Add support for generating test accounts with different `Status` values.

Closes #91 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version:
- Python version:
- Desktop/Mobile:
- OS:
- Browser:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
