### PR TITLE
Add dynamic redirect url for emails based on Origin header

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -19,6 +19,7 @@ export const register = async (req: Request, res: Response): Promise<void> => {
     email: string;
     password: string;
   };
+  const { origin } = req.headers;
   const email = emailRaw?.trim()?.toLowerCase();
 
   const registrationOpen = await isRegistrationOpen();
@@ -48,7 +49,7 @@ export const register = async (req: Request, res: Response): Promise<void> => {
 
   const emailToken = await user.generateEmailVerificationToken();
   try {
-    await EmailController.sendVerificationEmail(email, emailToken);
+    await EmailController.sendVerificationEmail(email, emailToken, origin);
   } catch (err) {
     console.error("Could not send verification email for registered user!");
     console.error(err);
@@ -173,6 +174,7 @@ export const resendVerificationEmail = async (
   if (emailRaw == null) {
     return bad(res, "Missing email");
   }
+  const { origin } = req.headers;
   const email = emailRaw?.trim()?.toLowerCase();
 
   try {
@@ -187,7 +189,7 @@ export const resendVerificationEmail = async (
 
     const emailToken = await user.generateEmailVerificationToken();
     try {
-      await EmailController.sendVerificationEmail(email, emailToken);
+      await EmailController.sendVerificationEmail(email, emailToken, origin);
       res.status(200).send();
     } catch (err) {
       error(res, "Could not send verification email");
@@ -257,6 +259,7 @@ export const sendPasswordResetEmail = async (
     return bad(res, "Missing email");
   }
   const email = emailRaw?.trim()?.toLowerCase();
+  const { origin } = req.headers;
 
   try {
     const user = await User.findOne({ email });
@@ -266,7 +269,11 @@ export const sendPasswordResetEmail = async (
 
     const passwordResetToken = user.generatePasswordResetToken();
     try {
-      await EmailController.sendPasswordResetEmail(email, passwordResetToken);
+      await EmailController.sendPasswordResetEmail(
+        email,
+        passwordResetToken,
+        origin
+      );
       res.status(200).send();
     } catch (err) {
       error(res, "Could not send password reset email");

--- a/src/controllers/EmailController.ts
+++ b/src/controllers/EmailController.ts
@@ -10,14 +10,16 @@ import { sendTemplateEmail } from "../services/email";
  */
 export const sendVerificationEmail = async (
   email: string,
-  verificationToken: string
+  verificationToken: string,
+  redirectUrl?: string
 ): Promise<void> => {
+  const baseUrl = redirectUrl ?? `${process.env.FRONTEND_URL}`;
   await sendTemplateEmail(
     [email],
     "[TartanHacks] Verify your email",
     "verification",
     {
-      url: `${process.env.FRONTEND_URL}/auth/verify/${verificationToken}`,
+      url: `${baseUrl}/auth/verify/${verificationToken}`,
     }
   );
 };
@@ -29,14 +31,16 @@ export const sendVerificationEmail = async (
  */
 export const sendPasswordResetEmail = async (
   email: string,
-  passwordResetToken: string
+  passwordResetToken: string,
+  redirectUrl?: string
 ): Promise<void> => {
+  const baseUrl = redirectUrl ?? `${process.env.FRONTEND_URL}`;
   await sendTemplateEmail(
     [email],
     "[TartanHacks] Reset your password",
     "password-reset",
     {
-      url: `${process.env.FRONTEND_URL}/auth/reset/${passwordResetToken}`,
+      url: `${baseUrl}/auth/reset/${passwordResetToken}`,
     }
   );
 };
@@ -66,15 +70,17 @@ export const sendRecruiterCreationEmail = async (
 
 export const sendStatusUpdateEmail = async (
   email: string,
-  name: string
+  name: string,
+  redirectUrl?: string
 ): Promise<void> => {
+  const url = redirectUrl ?? `${process.env.FRONTEND_URL}`;
   await sendTemplateEmail(
     [email],
     "[TartanHacks] Update regarding your application",
     "status-update",
     {
       name,
-      url: process.env.FRONTEND_URL,
+      url,
     }
   );
 };

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -25,7 +25,9 @@ const router: Router = express.Router();
  *   post:
  *     summary: Register user
  *     tags: [Authentication Module]
- *     description: Creates new user account. Access - Open
+ *     description: >
+ *       Creates new user account. This sends a verification email to the user containing a link to verify their account.
+ *       The base URL used in this verification link is from the request's `Origin` header. Access - Open
  *     requestBody:
  *       required: true
  *       content:
@@ -57,7 +59,7 @@ router.post("/register", asyncCatch(register));
  *   post:
  *     summary: Login user
  *     tags: [Authentication Module]
- *     description: |
+ *     description: >
  *      Verifies user credentials. Either the login credentials can be specified
  *      in the request body, or an access token can be specified in the header.. Access - Open
  *     requestBody:
@@ -120,7 +122,10 @@ router.get("/verify/:token", asyncCatch(verify));
  *   post:
  *     summary: Resend a user verification email
  *     tags: [Authentication Module]
- *     description: Resend a user verification email. Access - Open
+ *     description: >
+ *        Resend a user verification email.
+ *        This sends a verification email to the user containing a link to verify their account.
+ *        The base URL used in this verification link is from the request's `Origin` header. Access - Open
  *     requestBody:
  *       required: true
  *       content:
@@ -147,7 +152,10 @@ router.post("/verify/resend", asyncCatch(resendVerificationEmail));
  *   post:
  *     summary: Send a password reset email to a user
  *     tags: [Authentication Module]
- *     description: Send a password reset email to a user. Access - Open
+ *     description: >
+ *        Send a password reset email to a user.
+ *        This sends an email to the user containing a link to reset their password.
+ *        The base URL used in this reset link is from the request's `Origin` header. Access - Open
  *     requestBody:
  *       required: true
  *       content:


### PR DESCRIPTION
# Description

Dynamically change the base URL used in email links, based on the `Origin` header present in the request. If such a header is not present, the configured `FRONTEND_URL` environment variable on the backend is used. Affects `/auth/register`, `/auth/verify/resend`, and `/auth/request-reset`. 

Closes #94 
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version:
- Python version:
- Desktop/Mobile:
- OS:
- Browser:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
