### PR TITLE
script to get CSV of all project submission data (for speed judging)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # Output
 build/
+data/
 
 # macOS
 .DS_Store

--- a/scripts/get_project_csv.py
+++ b/scripts/get_project_csv.py
@@ -1,0 +1,112 @@
+import pymongo
+import python_dotenv
+import os
+
+# load env variables
+python_dotenv.load_dotenv("../.env")
+
+MONGO_CONNECTION_STRING = os.getenv("MONGODB_URI")
+# Project Database - Change to tartanhacks-25
+TARTANHACKS_DB = "tartanhacks-24"
+
+# Output file
+PROJECT_FILE = "24_projects.csv"
+
+# Prizes to consider
+# The script will only write projects
+# that have submitted to at least one of these prizes
+PRIZES_TO_CONSIDER = ["PLS Logistics Prize", "Ripple XRP Ledger Prize"]
+
+# connect to mongo
+client = pymongo.MongoClient(MONGO_CONNECTION_STRING)
+db = client[TARTANHACKS_DB]
+
+def load_project_info():
+    collection = db["projects"]
+    pipeline = [
+        {
+            "$lookup": {
+                "from": "teams",
+                "localField": "team",
+                "foreignField": "_id",
+                "as": "team_info"
+            }
+        },
+        {
+            "$unwind": {
+                "path": "$team_info",
+                "preserveNullAndEmptyArrays": True
+            }
+        },
+        {
+            "$lookup": {
+                "from": "prizes",
+                "localField": "prizes",
+                "foreignField": "_id",
+                "as": "prizes_info"
+            }
+        },
+        {
+            "$lookup": {
+                "from": "users",
+                "localField": "team_info.members",
+                "foreignField": "_id",
+                "as": "team_info.members"
+            }
+        },
+        {
+            "$project": {
+                "_id": 0,
+                "team": 0,
+                "name": 1,
+                "description": 1,
+                "url": 1,
+                "slides": 1,
+                "video": 1,
+                "team": 1,
+                "prizes": 1,
+                "team_name": "$team_info.name",
+                "prizes": "$prizes_info",
+            }
+        },
+    ]
+
+    projects = collection.aggregate(pipeline)
+
+    # write to CSV
+    import csv
+    with open(PROJECT_FILE, "w") as f:
+        fields = ["name", "description", "url", "slides", "video", "team_name", "prizes_of_interest"]
+        writer = csv.DictWriter(
+            f,
+            fieldnames=fields
+        )
+        writer.writeheader()
+
+        for proj in list(projects):
+            submitted_to_prizes_to_consider = False
+            proj_cleaned = {}
+
+            for field in fields:
+                if field == "prizes_of_interest":
+                    prizes = [
+                        prize["name"] for prize in proj["prizes"]
+                        if prize["name"] in PRIZES_TO_CONSIDER
+                    ]
+                    if prizes:
+                        submitted_to_prizes_to_consider = True
+
+                    proj_cleaned[field] = f"\"{', '.join(prizes)}\""
+                elif field not in proj:
+                    proj_cleaned[field] = None
+                else:
+                    proj_cleaned[field] = \
+                        f"\"{proj[field]}\"" if "," in proj[field] else proj[field]
+
+            if not submitted_to_prizes_to_consider:
+                continue
+                
+            writer.writerow(proj_cleaned)
+
+if __name__ == "__main__":
+    load_project_info()

--- a/scripts/get_project_csv.py
+++ b/scripts/get_project_csv.py
@@ -13,8 +13,8 @@ TARTANHACKS_DB = "tartanhacks-24"
 PROJECT_FILE = "24_projects.csv"
 
 # Prizes to consider
-# The script will only write projects
-# that have submitted to at least one of these prizes
+# The script will only write projects that have submitted to at least one of these prizes
+# Leave empty to consider all prizes
 PRIZES_TO_CONSIDER = ["PLS Logistics Prize", "Ripple XRP Ledger Prize"]
 
 # connect to mongo
@@ -89,10 +89,10 @@ def load_project_info():
 
             for field in fields:
                 if field == "prizes_of_interest":
-                    prizes = [
-                        prize["name"] for prize in proj["prizes"]
-                        if prize["name"] in PRIZES_TO_CONSIDER
-                    ]
+                    prizes = [prize["name"] for prize in proj["prizes"]]
+                    if PRIZES_TO_CONSIDER:
+                        prizes = filter(lambda x: x in PRIZES_TO_CONSIDER, prizes)
+
                     if prizes:
                         submitted_to_prizes_to_consider = True
 

--- a/scripts/get_project_csv.py
+++ b/scripts/get_project_csv.py
@@ -6,6 +6,10 @@ import os
 dotenv.load_dotenv("../.env")
 
 MONGO_CONNECTION_STRING = os.getenv("MONGODB_URI")
+
+if not MONGO_CONNECTION_STRING:
+    raise ValueError("MONGODB_URI not set in .env")
+
 # Project Database - Change to tartanhacks-25
 TARTANHACKS_DB = "tartanhacks-24"
 
@@ -105,7 +109,7 @@ def load_project_info():
 
             if not submitted_to_prizes_to_consider:
                 continue
-                
+
             writer.writerow(proj_cleaned)
 
 if __name__ == "__main__":

--- a/scripts/get_project_csv.py
+++ b/scripts/get_project_csv.py
@@ -1,9 +1,9 @@
 import pymongo
-import python_dotenv
+import dotenv
 import os
 
 # load env variables
-python_dotenv.load_dotenv("../.env")
+dotenv.load_dotenv("../.env")
 
 MONGO_CONNECTION_STRING = os.getenv("MONGODB_URI")
 # Project Database - Change to tartanhacks-25

--- a/scripts/get_project_csv.py
+++ b/scripts/get_project_csv.py
@@ -14,7 +14,7 @@ if not MONGO_CONNECTION_STRING:
 TARTANHACKS_DB = "tartanhacks-24"
 
 # Output file
-PROJECT_FILE = "24_projects.csv"
+PROJECT_FILE = "../data/24_projects.csv"
 
 # Prizes to consider
 # The script will only write projects that have submitted to at least one of these prizes
@@ -79,6 +79,10 @@ def load_project_info():
 
     # write to CSV
     import csv
+    # Check if directory exists
+    if not os.path.exists("../data"):
+        os.makedirs("../data")
+
     with open(PROJECT_FILE, "w") as f:
         fields = ["name", "description", "url", "slides", "video", "team_name", "prizes_of_interest"]
         writer = csv.DictWriter(

--- a/scripts/populate.py
+++ b/scripts/populate.py
@@ -159,12 +159,49 @@ def delete_judging_database():
 
 def synchronize():
     delete_judging_database()
-    response = requests.get(f"{JUDGING_URL}/api/synchronize")
+    requests.get(f"{JUDGING_URL}/api/synchronize")
+
+
+def create_sponsors():
+    with open('../data/sponsors.csv', mode='r') as sponsors_file:
+        csv_reader = csv.DictReader(sponsors_file)
+        for row in csv_reader:
+            sponsor_data = {
+                "name": row["name"],
+            }
+            sponsor_response = requests.post(
+                f"{API_URL}/sponsor",
+                json=sponsor_data,
+                headers={"x-access-token": JWT_SECRET}
+            )
+
+            print(f"Response for sponsor creation: {sponsor_response.status_code} - {sponsor_response.text}")
+
+
+def create_prizes():
+    with open('../data/prizes.csv', mode='r') as prizes_file:
+        csv_reader = csv.DictReader(prizes_file)
+        for row in csv_reader:
+            prize_data = {
+                "name": row["name"],
+                "description": row["description"],
+                "eligibility": row["eligibility"],
+                "sponsorName": row["sponsorName"],
+            }
+            prize_response = requests.post(
+                f"{API_URL}/prizes",
+                json=prize_data,
+                headers={"x-access-token": JWT_SECRET}
+            )
+
+            print(f"Response for prize creation: {prize_response.status_code} - {prize_response.text}")
 
 
 if __name__=='__main__':
     # create_users(3)
     # create_judges(3)
-    create_projects(3)
+    # create_projects(3)
     # delete_projects()
     # synchronize()
+    # create_sponsors()
+    create_prizes()

--- a/scripts/populate.py
+++ b/scripts/populate.py
@@ -7,7 +7,7 @@ import pymongo
 load_dotenv()
 
 API_URL = 'http://localhost:4000'
-JUDGING_URL = 'http://localhost:3000/judging'
+JUDGING_URL = 'http://localhost:3000'
 JWT_SECRET = os.getenv('JWT_SECRET')
 MONGO_CONNECTION_STRING = os.getenv("MONGODB_URI")
 JUDGING_DB = "tartanhacks-25-judging-dev"
@@ -159,7 +159,8 @@ def delete_judging_database():
 
 def synchronize():
     delete_judging_database()
-    requests.get(f"{JUDGING_URL}/api/synchronize")
+    response = requests.get(f"{JUDGING_URL}/api/synchronize")
+    print(f"Response for synchronization: {response.status_code} - {response.text}")
 
 
 def create_sponsors():
@@ -198,10 +199,10 @@ def create_prizes():
 
 
 if __name__=='__main__':
-    # create_users(3)
+    create_users(3)
     # create_judges(3)
     # create_projects(3)
     # delete_projects()
     # synchronize()
     # create_sponsors()
-    create_prizes()
+    # create_prizes()

--- a/scripts/populate.py
+++ b/scripts/populate.py
@@ -1,0 +1,170 @@
+import csv
+import os
+import requests
+from dotenv import load_dotenv
+import pymongo
+
+load_dotenv()
+
+API_URL = 'http://localhost:4000'
+JUDGING_URL = 'http://localhost:3000/judging'
+JWT_SECRET = os.getenv('JWT_SECRET')
+MONGO_CONNECTION_STRING = os.getenv("MONGODB_URI")
+JUDGING_DB = "tartanhacks-25-judging-dev"
+
+client = pymongo.MongoClient(MONGO_CONNECTION_STRING)
+db = client[JUDGING_DB]
+
+# Check if directory exists
+if not os.path.exists("../data"):
+    os.makedirs("../data")
+
+
+def create_users(n):
+    with open('../data/users.csv', mode='w', newline='') as file:
+        fieldnames = ["admin", "judge", "company", "status", "_id", "email", "createdAt", "updatedAt", "__v", "password", "token"]
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for i in range(n):
+            response = requests.post(
+                f"{API_URL}/test-account?status=CONFIRMED",
+                headers={"x-access-token": JWT_SECRET}
+            )
+
+            if response.status_code == 200:
+                user_data = response.json()
+                writer.writerow({
+                    "admin": user_data.get("admin", False),
+                    "judge": user_data.get("judge", False),
+                    "company": user_data.get("company", None),
+                    "status": user_data.get("status", "CONFIRMED"),
+                    "_id": user_data.get("_id"),
+                    "email": user_data.get("email"),
+                    "createdAt": user_data.get("createdAt"),
+                    "updatedAt": user_data.get("updatedAt"),
+                    "__v": user_data.get("__v", 0),
+                    "password": user_data.get("password"),
+                    "token": user_data.get("token")
+                })
+
+            print(f"Response for user {response.status_code} - {response.text}")
+
+
+def create_teams():
+    with open('../data/users.csv', mode='r') as users_file, open('../data/teams.csv', mode='w', newline='') as teams_file:
+        csv_reader = csv.DictReader(users_file)
+        fieldnames = ["_id", "name", "description", "visible", "user_email"]
+        writer = csv.DictWriter(teams_file, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for row in csv_reader:
+            team_data = {
+                "name": f"Team {row['email']}",
+                "description": "A team created by the script",
+                "visible": True
+            }
+            team_response = requests.post(
+                f"{API_URL}/team/",
+                json=team_data,
+                headers={"x-access-token": row['token']}
+            )
+
+            if team_response.status_code == 200:
+                team_data = team_response.json()
+                writer.writerow({
+                    "_id": team_data["_id"],
+                    "name": team_data["name"],
+                    "description": team_data["description"],
+                    "visible": team_data["visible"],
+                    "user_email": row["email"]
+                })
+
+            print(f"Response for team creation: {team_response.status_code} - {team_response.text}")
+
+
+def create_projects(n):
+    create_users(n)
+    create_teams()
+
+    with open('../data/teams.csv', mode='r') as teams_file:
+        csv_reader = csv.DictReader(teams_file)
+        for row in csv_reader:
+            project_data = {
+                "name": f"Project for {row['name']}",
+                "description": "A project created by the script",
+                "team": row["_id"],
+                "slides": "http://example.com/slides",
+                "video": "http://example.com/video",
+                "url": "http://example.com",
+                "presentingVirtually": True
+            }
+            project_response = requests.post(
+                f"{API_URL}/projects",
+                json=project_data,
+                headers={"x-access-token": JWT_SECRET}
+            )
+
+            print(f"Response for project creation: {project_response.status_code} - {project_response.text}")
+
+
+def delete_projects():
+    # Get projects
+    projects_response = requests.get(f"{API_URL}/projects", headers={"x-access-token": JWT_SECRET})
+    projects = projects_response.json()
+
+    # Delete projects
+    for project in projects:
+        project_id = project["_id"]
+        project_response = requests.delete(f"{API_URL}/projects/{project_id}", headers={"x-access-token": JWT_SECRET})
+        print(f"Response for project deletion: {project_response.status_code} - {project_response.text}")
+
+
+def create_judges(n):
+    create_users(n)
+
+    with open('../data/users.csv', mode='r') as users_file:
+        csv_reader = csv.DictReader(users_file)
+        judges = []
+        for row in csv_reader:
+            if row['email']:
+                judges.append(row['email'])
+
+        judge_response = requests.post(
+            f"{API_URL}/judges/",
+            json=judges,
+            headers={"x-access-token": JWT_SECRET}
+        )
+
+        # Copy users file to judges file using os but only the email and passwords by opening the csv and copying
+        with open('../data/users.csv', mode='r') as users_file, open('../data/judges.csv', mode='w', newline='') as judges_file:
+            csv_reader = csv.DictReader(users_file)
+            fieldnames = ["email", "password"]
+            writer = csv.DictWriter(judges_file, fieldnames=fieldnames)
+            writer.writeheader()
+
+            for row in csv_reader:
+                writer.writerow({
+                    "email": row["email"],
+                    "password": row["password"]
+                })
+
+
+        print(f"Response for judge creation: {judge_response.status_code} - {judge_response.text}")
+
+
+def delete_judging_database():
+    client.drop_database(JUDGING_DB)
+
+
+def synchronize():
+    delete_judging_database()
+    response = requests.get(f"{JUDGING_URL}/api/synchronize")
+
+
+if __name__=='__main__':
+    # create_users(3)
+    # create_judges(3)
+    create_projects(3)
+    # delete_projects()
+    # synchronize()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+dnspython==2.6.1
+pymongo==4.10.1
+python-dotenv==1.0.1

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 dnspython==2.6.1
 pymongo==4.10.1
 python-dotenv==1.0.1
+requests==2.26.0

--- a/src/controllers/TestAccount/accountCreator.ts
+++ b/src/controllers/TestAccount/accountCreator.ts
@@ -103,6 +103,13 @@ export async function createTestProfileForUser(user: IUser): Promise<IProfile> {
     ethnicity: pickRandom(Object.values(Ethnicity)),
     phoneNumber: "1234567890",
     github: displayName,
+    tartanHacksCodeOfConductAcknowledgement: true,
+    tartanHacksMediaReleaseAcknowledgement: true,
+    tartanHacksMediaReleaseSignature: true,
+    tartanHacksMediaReleaseDate: new Date(),
+    mlhCodeOfConductAcknowledgement: true,
+    mlhTermsAndConditionsAcknowledgement: true,
+    mlhEmailSubscription: true,
   });
   await profile.save();
 


### PR DESCRIPTION
# Description

Adds a script to get a CSV of all project submission data for judging (if not using Gavel). Adds the ability to filter by prizes of interest.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local testing on TartanHacks 2024 Database, and inspect output in Google Sheets

**Test Configuration**:

- Python version: 3.10
- Desktop/Mobile: Desktop
- OS: MacOS
